### PR TITLE
Add comment support using // syntax

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -1,0 +1,365 @@
+# DEV.md
+
+This document provides guidance for AI coding agents working on the
+cuentitos project. It defines the development process, workflows, and best
+practices to follow.
+
+## Development Flow
+
+The development process follows a structured 7-phase approach:
+
+**Feature Plan → Test Plan → Implement Tests → Implementation Plan → TDD
+Development → Verify → Document**
+
+Each phase has specific goals and guidelines detailed below.
+
+---
+
+## Phase 1: Feature Plan
+
+**Goal:** Understand the feature requirements through interactive
+discussion.
+
+**Process:**
+1. Ask questions **one by one** to understand the feature
+2. Start with **high-level questions** first (e.g., "What should comments
+   look like?"), then drill down to specifics
+3. Ask **as many questions as needed** for full clarity
+4. Explore the codebase **anytime needed** to understand context
+
+**Guidelines:**
+- Be thorough - it's better to ask too many questions than too few
+- Don't make assumptions; always ask when uncertain
+- Take notes on requirements as they're discussed
+
+**Output:** Clear understanding of feature requirements and behavior.
+
+---
+
+## Phase 2: Test Plan
+
+**Goal:** Define all compatibility tests needed to verify the feature.
+
+**Process:**
+1. **Explore existing compatibility tests** in `compatibility-tests/` to
+   understand format and patterns
+2. **Propose a list** of test scenarios covering:
+   - Happy path cases
+   - Edge cases
+   - Error cases
+   - Integration with existing features
+3. **Discuss each test scenario one by one** to refine and confirm
+
+**Guidelines:**
+- Understand the test format thoroughly - don't ask about format
+  repeatedly
+- Ensure tests are comprehensive enough to define "done"
+- Consider interactions with existing features
+
+**Output:** Agreed-upon list of test scenarios to implement.
+
+---
+
+## Phase 3: Implement Tests
+
+**Goal:** Write all compatibility tests (which should fail initially).
+
+**Process:**
+1. **Write all test files at once** following the compatibility test
+   format.
+2. **Run `./bin/run-compat`** after creating tests
+3. **Show the output** and confirm the failures are correct (Red phase
+   of TDD)
+
+**Guidelines:**
+- Tests should fail for the right reasons (feature not implemented, not
+  syntax errors)
+- Place tests in appropriate subdirectories of `compatibility-tests/`
+- Follow naming conventions from existing tests
+
+**Output:** Complete set of failing compatibility tests.
+
+---
+
+## Phase 4: Implementation Plan
+
+**Goal:** Design the technical approach and architecture for the
+implementation.
+
+**Process:**
+1. **Explore the codebase** to understand:
+   - Current architecture (e.g., how block parsers work)
+   - Existing patterns to follow
+   - Where new code should go
+2. **Propose the architectural approach** with trade-offs
+3. **Ask architectural questions one by one** to discuss decisions
+4. **Write a draft ADR** (Architecture Decision Record) documenting:
+   - Context and problem
+   - Considered options
+   - Chosen solution and rationale
+   - Consequences
+
+**Guidelines:**
+- Follow existing architectural patterns when possible
+- Consider extensibility and maintainability
+- Document why decisions were made, not just what
+- Be conservative - ask when uncertain about architectural choices
+
+**Output:**
+- Clear implementation strategy
+- Draft ADR in `docs/architecture/`
+- Agreement on approach
+
+---
+
+## Phase 5: TDD Development
+
+**Goal:** Implement the feature using Test-Driven Development.
+
+**Process:**
+1. Work on **one failing test at a time**:
+   - Write minimal code to make it pass (Green)
+   - Refactor for quality (Refactor)
+   - Move to next test
+2. **Run tests after each change** to prevent regression:
+   - Run `./bin/run-compat` for compatibility tests
+   - Run `cargo test` for unit tests
+3. **Commit after logical units** are complete (e.g., a class, module,
+   or coherent feature chunk)
+4. **Push to origin** automatically after each commit
+
+**Guidelines:**
+- Write Rust unit tests for complex logic and validation rules
+- Don't rely solely on compatibility tests - add unit tests too
+- Keep commits focused and atomic
+- If you get stuck, **ask for help** immediately
+- If a refactoring breaks existing tests, **stop and ask** before
+  proceeding
+- Run both compatibility tests and unit tests frequently
+
+**Commit Messages:**
+- Use clear, descriptive messages
+- **Do NOT include Claude Code branding** or co-author tags
+- Format: Start with a verb (e.g., "Add comment parsing", "Fix
+  indentation validation")
+
+**Output:** Working implementation with all tests passing.
+
+---
+
+## Phase 6: Verify
+
+**Goal:** Ensure code quality and catch any issues before completion.
+
+**Process:**
+1. **Run the full verification suite:**
+   - `cargo test` - All unit tests
+   - `./bin/run-compat` - All compatibility tests
+   - `cargo clippy` - Linting
+   - `cargo fmt` - Formatting
+   - `cargo doc` - Build and test Rust docs
+2. **Invoke the code review agent:**
+   - Use a sub-agent called "cuentitos-reviewer"
+   - This agent will perform a thorough code review
+3. **Create a code review report** with:
+   - Issues found (if any)
+   - Suggestions for improvement
+   - Code quality observations
+4. **Present the report** to the user who will decide what to address
+
+**Guidelines:**
+- Don't automatically fix review findings - present them first
+- All tests must pass before moving to Document phase
+- No clippy warnings should remain
+- Code should be properly formatted
+
+**Output:**
+- Clean verification run (all tests pass, no warnings)
+- Code review report
+- Fixes applied per user decision
+
+---
+
+## Phase 7: Document
+
+**Goal:** Create comprehensive documentation for the feature.
+
+**Process:**
+1. **Create a documentation plan** covering:
+   - ADR finalization
+   - CLAUDE.md updates (if needed)
+   - Inline code documentation
+   - Rust doc comments
+   - User manual additions
+2. **Ask questions one by one** about documentation decisions
+3. For the **user manual** (when it exists):
+   - Ask about structure/format desired
+   - Provide a plan before writing
+   - Ask questions one by one about content
+4. **Write all documentation**
+5. **Commit documentation separately** from implementation code
+
+**Guidelines:**
+- Documentation should be clear and thorough
+- Include examples where helpful
+- Update CLAUDE.md if the feature changes development patterns
+- Ensure Rust docs build without warnings
+
+**Output:** Complete documentation committed separately.
+
+---
+
+## TODO.md Workflow
+
+**How to use TODO.md:**
+1. **Mark items as done** `[x]` after full implementation (all phases
+   complete)
+2. **Add new discovered tasks** as you encounter them during development
+3. Items are organized in sections (Compat, Language, Compiler, Plugins)
+
+**Do NOT:**
+- Mark items as done before they're truly complete
+- Remove items without completing them
+- Reorder items arbitrarily
+
+---
+
+## Branching & Pull Requests
+
+**Branch Naming:**
+- Format: `v3-todo-item-name`
+- Example: `v3-support-comments`
+- Use the `./bin/start-feature` script (when available) to select a
+  feature from TODO.md and create a branch
+
+**Pull Request Workflow:**
+1. **Create PR after Feature Plan phase** with:
+   - Description of the feature
+   - Draft ADR included
+   - Mark as draft if not ready for review
+2. **Update PR with each commit:**
+   - Commits automatically push to origin
+   - PR updates automatically
+3. **Mark PR as ready** after Document phase is complete
+
+**Commit Guidelines:**
+- Push to origin automatically after each commit
+- Keep commits atomic and focused
+- **No Claude Code branding** in commit messages
+- Commit logical units (classes, modules) together
+- Commit documentation separately from implementation
+
+---
+
+## Decision-Making & Autonomy
+
+**When to Ask:**
+- Encountering ambiguity or uncertainty (e.g., "Should this error be
+  fatal?")
+- Stuck during implementation
+- A refactoring breaks existing tests
+- Architectural decisions
+- Documentation structure decisions
+
+**Be Conservative:**
+- Ask more questions rather than fewer
+- Don't make assumptions
+- When in doubt, ask
+
+**No Pre-Approval Required For:**
+- Adding dependencies (but document in ADR)
+- Changing public APIs (but document in ADR)
+- Most implementation decisions (but be ready to explain)
+
+---
+
+## Key Principles
+
+1. **Test-Driven Development** - Write tests first, implement to make
+   them pass
+2. **Run tests frequently** - After each change to catch regressions
+   early
+3. **Ask questions one by one** - Don't batch questions; interactive
+   discussion works best
+4. **Be thorough** - Better to ask too many questions than too few
+5. **Document decisions** - ADRs explain why, not just what
+6. **Commit logical units** - Keep commits focused and atomic
+7. **Explore as needed** - Look at the codebase whenever context is
+   needed
+
+---
+
+## Common Commands Reference
+
+```bash
+# Build the project
+cargo build
+
+# Run all tests
+cargo test
+
+# Run tests for a specific package
+cargo test -p cuentitos-parser
+
+# Run compatibility tests
+./bin/run-compat
+
+# Run linting
+cargo clippy
+
+# Format code
+cargo fmt
+
+# Build documentation
+cargo doc
+
+# Run the CLI
+cargo run --bin cuentitos run <script_path> <input_string>
+
+# Start working on a feature (when available)
+./bin/start-feature
+```
+
+---
+
+## Code Quality Standards
+
+**Must Pass:**
+- All unit tests (`cargo test`)
+- All compatibility tests (`./bin/run-compat`)
+- Clippy with no warnings (`cargo clippy`)
+- Formatted code (`cargo fmt`)
+- Documentation builds (`cargo doc`)
+
+**Code Style:**
+- Write clear, idiomatic Rust code
+- Use expressive variable names (e.g., `is_ready`, `has_data`)
+- Follow Rust naming conventions: snake_case for functions/variables,
+  PascalCase for types
+- Embrace ownership and the type system
+- Avoid code duplication
+- Add meaningful comments for complex logic
+
+---
+
+## Architecture Notes
+
+- Indentation is **2 spaces per level** (enforced by parser)
+- Blocks form a hierarchy where indentation determines parent-child
+  relationships
+- Parser is line-based and extensible through block parsers
+- See `docs/architecture/` for ADRs explaining design decisions
+- See CLAUDE.md for project overview and architecture details
+
+---
+
+## Notes for AI Agents
+
+- **Don't surprise the user** - ask before taking major actions
+- **Explore the codebase freely** - you can read files anytime to
+  understand context
+- **Use the compatibility tests** - they are the source of truth for
+  behavior
+- **Follow TDD strictly** - Red (write test) → Green (make it pass) →
+  Refactor
+- **Be patient and thorough** - quality matters more than speed

--- a/TODO.md
+++ b/TODO.md
@@ -4,8 +4,6 @@
   - [ ] Fix all unwraps in `TestRunner#run` to do proper error handling
 
 # Language
-  - [ ] I18n for Strings
-  - [ ] Docs for how the engine reads lines
   - [x] Block Parenting (Docs & Implementation)
   - [x] Sections & Sub-sections (Docs & Implementation)
   - [ ] Support comments
@@ -29,6 +27,8 @@
   - [ ] Probabilistic Buckets (Docs & Implementation)
   - [ ] Probabilistic Frequency manipulation (Docs & Implementation)
   - [ ] Function Calling (Docs & Implementation)
+  - [ ] I18n for Strings
+  - [ ] Docs for how the engine reads lines
 
 # Compiler
   - [ ] Script to JSON (Docs & Implementation)
@@ -40,3 +40,9 @@
   - [ ] Characters (Docs & Implementation)
   - [ ] Background Music (Docs & Implementation)
   - [ ] Sound Effects (Docs & Implementation)
+
+# Documentation
+  - [ ] User Manual (Create comprehensive user-facing documentation for the language)
+
+# Tooling
+  - [ ] Create `./bin/start-feature` TUI script to select and start working on TODO items

--- a/bin/start-feature
+++ b/bin/start-feature
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+TODO_FILE="TODO.md"
+
+# Check if TODO.md exists
+if [ ! -f "$TODO_FILE" ]; then
+  echo "Error: TODO.md not found"
+  exit 1
+fi
+
+# Extract unchecked items from TODO.md with their section
+items=()
+current_section=""
+
+while IFS= read -r line; do
+  # Check if line is a section header
+  if [[ $line =~ ^#[[:space:]](.+)$ ]]; then
+    current_section="${BASH_REMATCH[1]}"
+  # Check if line is an unchecked item
+  elif [[ $line =~ ^[[:space:]]*-[[:space:]]\[[[:space:]]\][[:space:]](.+)$ ]]; then
+    item_text="${BASH_REMATCH[1]}"
+    items+=("[$current_section] $item_text")
+  fi
+done < "$TODO_FILE"
+
+# Check if there are any unchecked items
+if [ ${#items[@]} -eq 0 ]; then
+  echo "No unchecked items found in TODO.md"
+  exit 0
+fi
+
+echo -e "${BLUE}Select a feature to start working on:${NC}\n"
+
+# Use fzf if available, otherwise use select
+if command -v fzf &> /dev/null; then
+  selected=$(printf "%s\n" "${items[@]}" | fzf --height=20 --reverse \
+    --prompt="Feature: " --header="Use arrow keys to navigate, Enter to select")
+else
+  # Fallback to bash select
+  PS3=$'\nEnter number: '
+  select selected in "${items[@]}"; do
+    if [ -n "$selected" ]; then
+      break
+    fi
+  done
+fi
+
+# Check if user cancelled selection
+if [ -z "$selected" ]; then
+  echo "Selection cancelled"
+  exit 0
+fi
+
+echo -e "\n${GREEN}Selected:${NC} $selected"
+
+# Extract just the feature name (remove section prefix and any trailing info)
+# Remove the [Section] prefix
+feature_name=$(echo "$selected" | sed 's/^\[.*\][[:space:]]*//')
+# Remove any text in parentheses at the end
+feature_name=$(echo "$feature_name" | sed 's/[[:space:]]*(.*)[[:space:]]*$//')
+# Convert to lowercase and replace spaces with hyphens
+branch_name=$(echo "$feature_name" | tr '[:upper:]' '[:lower:]' | \
+  tr ' ' '-' | sed 's/[^a-z0-9-]//g')
+branch_name="v3-${branch_name}"
+
+echo -e "${YELLOW}Creating branch:${NC} $branch_name"
+
+# Check if branch already exists
+if git show-ref --verify --quiet "refs/heads/$branch_name"; then
+  echo -e "${YELLOW}Branch already exists. Checking it out...${NC}"
+  git checkout "$branch_name"
+else
+  # Create and checkout new branch
+  git checkout -b "$branch_name"
+fi
+
+echo -e "\n${GREEN}✓ Ready to start working on: $feature_name${NC}"
+echo -e "${BLUE}Next steps:${NC}"
+echo "  1. Follow the development flow in DEV.md"
+echo "  2. Start with the Feature Plan phase"
+echo "  3. Create a PR after the Feature Plan phase"

--- a/compatibility-tests/00000000020-single-comment-line.md
+++ b/compatibility-tests/00000000020-single-comment-line.md
@@ -1,0 +1,19 @@
+# Single Comment Line
+
+A script with just a comment should be completely ignored and show only START and END.
+
+## Script
+```cuentitos
+// This is a comment
+```
+
+## Input
+```input
+s
+```
+
+## Result
+```result
+START
+END
+```

--- a/compatibility-tests/00000000021-comment-before-text.md
+++ b/compatibility-tests/00000000021-comment-before-text.md
@@ -1,0 +1,21 @@
+# Comment Before Text
+
+A comment at the start should be ignored, followed by regular text.
+
+## Script
+```cuentitos
+// This is a comment
+This is a line of text
+```
+
+## Input
+```input
+s
+```
+
+## Result
+```result
+START
+This is a line of text
+END
+```

--- a/compatibility-tests/00000000022-comment-after-text.md
+++ b/compatibility-tests/00000000022-comment-after-text.md
@@ -1,0 +1,21 @@
+# Comment After Text
+
+Regular text followed by a comment that should be ignored.
+
+## Script
+```cuentitos
+This is a line of text
+// This is a comment
+```
+
+## Input
+```input
+s
+```
+
+## Result
+```result
+START
+This is a line of text
+END
+```

--- a/compatibility-tests/00000000023-comment-between-text-lines.md
+++ b/compatibility-tests/00000000023-comment-between-text-lines.md
@@ -1,0 +1,23 @@
+# Comment Between Text Lines
+
+A comment between two text lines should be ignored.
+
+## Script
+```cuentitos
+First line of text
+// This is a comment
+Second line of text
+```
+
+## Input
+```input
+s
+```
+
+## Result
+```result
+START
+First line of text
+Second line of text
+END
+```

--- a/compatibility-tests/00000000024-multiple-consecutive-comments.md
+++ b/compatibility-tests/00000000024-multiple-consecutive-comments.md
@@ -1,0 +1,23 @@
+# Multiple Consecutive Comments
+
+Multiple comment lines in a row should all be ignored.
+
+## Script
+```cuentitos
+// First comment
+// Second comment
+// Third comment
+This is text
+```
+
+## Input
+```input
+s
+```
+
+## Result
+```result
+START
+This is text
+END
+```

--- a/compatibility-tests/00000000025-comments-in-sections.md
+++ b/compatibility-tests/00000000025-comments-in-sections.md
@@ -1,0 +1,32 @@
+# Comments in Sections
+
+Comments mixed with section content should be ignored.
+
+## Script
+```cuentitos
+# First Section
+// Comment in first section
+This is text in the first section
+// Another comment
+This is more text
+
+# Second Section
+// Comment in second section
+This is text in the second section
+```
+
+## Input
+```input
+s
+```
+
+## Result
+```result
+START
+-> First Section
+This is text in the first section
+This is more text
+-> Second Section
+This is text in the second section
+END
+```

--- a/compatibility-tests/00000000026-comments-at-different-indentation-levels.md
+++ b/compatibility-tests/00000000026-comments-at-different-indentation-levels.md
@@ -1,0 +1,27 @@
+# Comments at Different Indentation Levels
+
+Comments at various indentation levels (following normal hierarchy) should be ignored.
+
+## Script
+```cuentitos
+// Comment at level 0
+# First Section
+  // Comment at level 1
+  Text at level 1
+    // Comment at level 2
+    Text at level 2
+```
+
+## Input
+```input
+s
+```
+
+## Result
+```result
+START
+-> First Section
+Text at level 1
+Text at level 2
+END
+```

--- a/compatibility-tests/00000000027-comments-with-arbitrary-indentation.md
+++ b/compatibility-tests/00000000027-comments-with-arbitrary-indentation.md
@@ -1,0 +1,32 @@
+# Comments with Arbitrary Indentation
+
+Comments can have arbitrary indentation without following hierarchy rules.
+
+## Script
+```cuentitos
+// Comment at level 0
+      // Comment at level 3 (skipping levels)
+  // Comment at level 1
+Text at level 0
+# Section
+  Text at level 1
+    // Comment at level 2
+      // Comment at level 3
+  // Comment at level 1
+  More text at level 1
+```
+
+## Input
+```input
+s
+```
+
+## Result
+```result
+START
+Text at level 0
+-> Section
+Text at level 1
+More text at level 1
+END
+```

--- a/compatibility-tests/00000000028-empty-comment.md
+++ b/compatibility-tests/00000000028-empty-comment.md
@@ -1,0 +1,22 @@
+# Empty Comment
+
+A comment with just // and no text should be valid and ignored.
+
+## Script
+```cuentitos
+//
+This is text
+//
+```
+
+## Input
+```input
+s
+```
+
+## Result
+```result
+START
+This is text
+END
+```

--- a/compatibility-tests/00000000029-comment-with-whitespace-before.md
+++ b/compatibility-tests/00000000029-comment-with-whitespace-before.md
@@ -1,0 +1,22 @@
+# Comment with Whitespace Before //
+
+Comments can have extra spaces between indentation and //.
+
+## Script
+```cuentitos
+  // Comment with 2 spaces indentation
+   // Comment with extra space after indentation
+This is text
+```
+
+## Input
+```input
+s
+```
+
+## Result
+```result
+START
+This is text
+END
+```

--- a/compatibility-tests/00000000030-multiple-slash-symbols.md
+++ b/compatibility-tests/00000000030-multiple-slash-symbols.md
@@ -1,0 +1,22 @@
+# Multiple Slash Symbols
+
+Comments with multiple // symbols (///, ////, etc.) should be valid.
+
+## Script
+```cuentitos
+/// Triple slash comment
+//// Quadruple slash comment
+This is text
+```
+
+## Input
+```input
+s
+```
+
+## Result
+```result
+START
+This is text
+END
+```

--- a/docs/architecture/000012-comment-support.md
+++ b/docs/architecture/000012-comment-support.md
@@ -1,0 +1,171 @@
+# Comment Support
+
+### Submitters
+
+- Fran Tufro
+
+## Change Log
+
+- [pending] 2025-10-02 - Draft ADR for comment support feature
+
+## Referenced Use Case(s)
+
+- [Single Comment Line](../../compatibility-tests/00000000020-single-comment-line.md)
+- [Comment Before Text](../../compatibility-tests/00000000021-comment-before-text.md)
+- [Comment Between Text Lines](../../compatibility-tests/00000000023-comment-between-text-lines.md)
+- [Comments in Sections](../../compatibility-tests/00000000025-comments-in-sections.md)
+- [Comments with Arbitrary Indentation](../../compatibility-tests/00000000027-comments-with-arbitrary-indentation.md)
+
+## Context
+
+Cuentitos scripts currently lack a mechanism for adding explanatory notes, documentation, or temporarily disabling code without removing it. Comments are a fundamental feature in programming languages and authoring environments that enable developers to:
+- Document the purpose and behavior of script sections
+- Add notes for future reference
+- Temporarily disable content during development
+- Improve script readability and maintainability
+
+This ADR proposes adding comment support using `//` syntax, where comments are completely ignored by the parser and can appear at any indentation level.
+
+## Proposed Design
+
+### Comment Syntax
+
+Comments use double-slash syntax:
+```cuentitos
+// This is a comment
+Text line
+// Another comment
+
+# Section
+  // Comment within section
+  Text in section
+```
+
+### Key Requirements
+
+1. **Syntax**: Lines starting with `//` (after any whitespace) are comments
+2. **Placement**: Comments must be on their own line (not inline after content)
+3. **Indentation**: Comments can appear at any indentation level, not bound by hierarchy rules
+4. **Multiple slashes**: `///`, `////`, etc. are all valid comments
+5. **Empty comments**: `//` alone with no text is valid
+6. **Parser behavior**: Comments are completely ignored and not stored in the Database
+
+### Implementation Options
+
+#### Option 1: Early Skip in Parse Loop (Recommended)
+
+Check if a line is a comment immediately after reading it in the main parse loop, before indentation validation. If it's a comment, skip to the next line.
+
+**Pros:**
+- Simple and clean
+- Comments truly ignored (similar to blank lines)
+- No indentation validation applied (enables arbitrary indentation)
+- Minimal code changes
+- Treats comments as non-content (philosophically correct)
+
+**Cons:**
+- Doesn't follow the FeatureParser trait pattern
+
+**Implementation Location:**
+- Add helper method `is_comment(line: &str) -> bool`
+- Add check in `Parser::parse()` main loop before indentation parsing
+
+#### Option 2: Create CommentParser with FeatureParser Trait
+
+Implement a `CommentParser` following the existing `FeatureParser` pattern like `SectionParser` and `LineParser`.
+
+**Pros:**
+- Consistent with existing parser architecture
+- Extensible if comments need features later
+- Follows established patterns
+
+**Cons:**
+- More complex for something that should be ignored
+- Still requires special handling for indentation validation
+- Comments would need to go through the full parsing pipeline just to be discarded
+- Philosophical mismatch: FeatureParsers create content, comments are non-content
+
+#### Option 3: Pre-process Script to Remove Comments
+
+Strip comments from the input before passing to the parser.
+
+**Pros:**
+- Parser doesn't need to know about comments
+- Very clean separation
+
+**Cons:**
+- Line numbers in error messages become incorrect
+- More complex overall architecture
+- Preprocessing step adds overhead
+
+## Considerations
+
+### Why `//` instead of `#`?
+
+Initially considered using `#` for comments, but discovered that `#` is already used for section headers in the language. Using `//` avoids this conflict and aligns with common programming language conventions (C++, JavaScript, Rust, etc.).
+
+### Indentation Validation
+
+Since comments can have arbitrary indentation (not following hierarchy rules), they must be detected and skipped **before** indentation validation occurs. This is a key difference from other content types.
+
+### Parser Architecture Consistency
+
+While the codebase uses the `FeatureParser` trait pattern for extensible parsing, comments are fundamentally different - they are non-content that should be eliminated, not parsed and stored. An early skip is more appropriate than a full parser implementation.
+
+### Future Extensibility
+
+If comments ever need to support features like:
+- Documentation generation
+- Special comment directives
+- Block comments (`/* */`)
+
+The early-skip approach can be refactored to use a CommentParser at that time. YAGNI principle applies: don't add complexity for hypothetical future needs.
+
+## Decision
+
+**Implement Option 1: Early Skip in Parse Loop**
+
+Comments will be detected and skipped early in the parse loop, before indentation validation. This approach:
+- Achieves the goal of completely ignoring comments
+- Allows arbitrary indentation without validation errors
+- Keeps implementation simple and maintainable
+- Treats comments philosophically correctly as non-content
+
+### Implementation Details
+
+1. Add helper method to `Parser`:
+   ```rust
+   fn is_comment(line: &str) -> bool {
+       line.trim_start().starts_with("//")
+   }
+   ```
+
+2. In `Parser::parse()` main loop, check for comments after reading each line:
+   ```rust
+   for line in script.as_ref().lines() {
+       // Check if line is a comment and skip it
+       if Self::is_comment(line) {
+           context.current_line += 1;
+           continue;
+       }
+
+       // ... rest of existing parsing logic
+   }
+   ```
+
+3. No changes needed to:
+   - Database structure
+   - Block types
+   - FeatureParser implementations
+   - Runtime execution
+
+## Other Related ADRs
+
+- [Modular Parser Architecture](000010-modular-parser-architecture.md) - Context for parser design patterns
+- [Sections and Navigation](000011-sections-and-navigation.md) - Why `#` was unavailable for comments
+- [Parser](000004-parser.md) - Original parser architecture
+
+## References
+
+- [C++ Comments](https://en.cppreference.com/w/cpp/comment) - Similar `//` syntax
+- [Rust Comments](https://doc.rust-lang.org/reference/comments.html) - Documentation comments with `///`


### PR DESCRIPTION
## Summary

Implements comment support for cuentitos scripts using `//` syntax. Comments are completely ignored by the parser and can appear at any indentation level.

## Feature Requirements

- Syntax: Lines starting with `//` (after any whitespace) are comments
- Comments must be on their own line (not inline)
- Comments can have arbitrary indentation (not bound by hierarchy rules)
- Multiple slashes (`///`, `////`) are valid
- Empty comments (`//` alone) are valid
- Parser completely ignores comments (not stored in Database)

## Implementation Status

- [x] Phase 1: Feature Plan - Requirements gathered
- [x] Phase 2: Test Plan - 11 compatibility tests defined
- [x] Phase 3: Implement Tests - All tests created and failing (Red phase)
- [x] Phase 4: Implementation Plan - Draft ADR created
- [ ] Phase 5: TDD Development - Not started
- [ ] Phase 6: Verify - Not started
- [ ] Phase 7: Document - Not started

## Test Coverage

11 compatibility tests covering:
- Single comment lines
- Comments before, after, and between text
- Multiple consecutive comments
- Comments in sections
- Comments at different indentation levels
- Comments with arbitrary indentation
- Empty comments
- Comments with extra whitespace
- Multiple slash symbols

## Architecture Decision

See [ADR 000012: Comment Support](docs/architecture/000012-comment-support.md) for detailed design rationale.

The implementation uses an early-skip approach in the parse loop, detecting and ignoring comments before indentation validation. This allows arbitrary indentation and keeps the implementation simple.