### PR TITLE
Enum variable definitions: parse, validate, and display

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -457,13 +457,17 @@ fn print_debug_variables(runtime: &cuentitos_runtime::Runtime, script_path: &Pat
     debug_assert_eq!(values.len(), runtime.database.variables.len());
     for (variable, value) in runtime.database.variables.iter().zip(values) {
         // Dispatch on the `Value` variant so each kind controls its own
-        // textual rendering. New variants (Float/String) just add a match
-        // arm here.
+        // textual rendering. New variants (Float/String/EnumUnset) just add a
+        // match arm here.
         let formatted = match value {
             cuentitos_common::Value::Integer(n) => format!("{n}"),
             cuentitos_common::Value::Boolean(b) => format!("{b}"),
             cuentitos_common::Value::Float(x) => cuentitos_common::value::format_float(*x),
             cuentitos_common::Value::String(s) => cuentitos_common::value::format_string_literal(s),
+            // An unset enum: `?` is exempt from the runtime read-error and
+            // must report `<unset>` without raising. The set suite exercises
+            // the error path via `req`.
+            cuentitos_common::Value::EnumUnset { .. } => "<unset>".to_string(),
         };
         println!("{}: {}", variable.name, formatted);
     }

--- a/common/src/value.rs
+++ b/common/src/value.rs
@@ -18,6 +18,13 @@ pub enum Value {
     Boolean(bool),
     Float(f64),
     String(String),
+    /// An enum variable that has not yet been assigned a value. Carries the
+    /// list of allowed variant names so the runtime can validate `set` targets
+    /// without a separate lookup. The `?` debug inspector prints `<unset>`;
+    /// reading this value at runtime (outside the inspector) is an error.
+    EnumUnset {
+        variants: Vec<String>,
+    },
 }
 
 impl Value {
@@ -29,6 +36,7 @@ impl Value {
             Value::Boolean(_) => ValueKind::Boolean,
             Value::Float(_) => ValueKind::Float,
             Value::String(_) => ValueKind::String,
+            Value::EnumUnset { .. } => ValueKind::Enum,
         }
     }
 
@@ -39,7 +47,9 @@ impl Value {
     pub fn as_integer(&self) -> Option<i64> {
         match self {
             Value::Integer(n) => Some(*n),
-            Value::Boolean(_) | Value::Float(_) | Value::String(_) => None,
+            Value::Boolean(_) | Value::Float(_) | Value::String(_) | Value::EnumUnset { .. } => {
+                None
+            }
         }
     }
 
@@ -51,7 +61,9 @@ impl Value {
     pub fn as_float(&self) -> Option<f64> {
         match self {
             Value::Float(f) => Some(*f),
-            Value::Integer(_) | Value::Boolean(_) | Value::String(_) => None,
+            Value::Integer(_) | Value::Boolean(_) | Value::String(_) | Value::EnumUnset { .. } => {
+                None
+            }
         }
     }
 
@@ -64,7 +76,9 @@ impl Value {
     pub fn as_string(&self) -> Option<&str> {
         match self {
             Value::String(s) => Some(s),
-            Value::Integer(_) | Value::Boolean(_) | Value::Float(_) => None,
+            Value::Integer(_) | Value::Boolean(_) | Value::Float(_) | Value::EnumUnset { .. } => {
+                None
+            }
         }
     }
 }
@@ -78,6 +92,10 @@ impl std::fmt::Display for Value {
             // The raw string content, unquoted. The double-quoted, escaped form
             // used by the `?` debug command lives in [`format_string_literal`].
             Value::String(s) => write!(f, "{s}"),
+            // The `?` debug inspector is exempt from the runtime read-error
+            // and prints `<unset>` directly. Other `Display` sites (e.g.
+            // interpolation) should never reach an unset enum at runtime.
+            Value::EnumUnset { .. } => write!(f, "<unset>"),
         }
     }
 }
@@ -141,6 +159,7 @@ pub enum ValueKind {
     Boolean,
     Float,
     String,
+    Enum,
 }
 
 impl ValueKind {
@@ -149,7 +168,7 @@ impl ValueKind {
     pub fn is_numeric(self) -> bool {
         match self {
             ValueKind::Integer | ValueKind::Float => true,
-            ValueKind::Boolean | ValueKind::String => false,
+            ValueKind::Boolean | ValueKind::String | ValueKind::Enum => false,
         }
     }
 
@@ -158,12 +177,12 @@ impl ValueKind {
     pub fn is_ordered(self) -> bool {
         match self {
             ValueKind::Integer | ValueKind::Float => true,
-            ValueKind::Boolean | ValueKind::String => false,
+            ValueKind::Boolean | ValueKind::String | ValueKind::Enum => false,
         }
     }
 
     /// The source-syntax keyword that declares this kind (`int`, `bool`,
-    /// `float`).
+    /// `float`, `string`, `enum`).
     ///
     /// Distinct from [`Display`](std::fmt::Display), which renders the full
     /// English word (`integer`, `boolean`) used in `set`/`req` diagnostics.
@@ -176,6 +195,7 @@ impl ValueKind {
             ValueKind::Boolean => "bool",
             ValueKind::Float => "float",
             ValueKind::String => "string",
+            ValueKind::Enum => "enum",
         }
     }
 }
@@ -187,6 +207,7 @@ impl std::fmt::Display for ValueKind {
             ValueKind::Boolean => write!(f, "boolean"),
             ValueKind::Float => write!(f, "float"),
             ValueKind::String => write!(f, "string"),
+            ValueKind::Enum => write!(f, "enum"),
         }
     }
 }

--- a/parser/src/expression.rs
+++ b/parser/src/expression.rs
@@ -359,7 +359,7 @@ mod tests {
             .collect();
         match evaluate(&expression, &|id| &values[&id])?.into_owned() {
             Value::Integer(n) => Ok(n),
-            Value::Boolean(_) | Value::Float(_) | Value::String(_) => {
+            Value::Boolean(_) | Value::Float(_) | Value::String(_) | Value::EnumUnset { .. } => {
                 unreachable!("arithmetic folds only produce integers")
             }
         }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -440,6 +440,61 @@ pub enum ParseError {
     MultipleErrors {
         errors: Vec<ParseError>,
     },
+    /// A `set` on a bool variable had a non-bool RHS. Parallel in shape to
+    /// [`FloatSetTypeMismatch`](Self::FloatSetTypeMismatch): names the
+    /// offending sub-expression (`found_token`) and its kind rather than just
+    /// reporting two kinds, so the wording echoes what the author typed.
+    BoolSetTypeMismatch {
+        variable: String,
+        found_token: String,
+        found: cuentitos_common::ValueKind,
+        file: Option<PathBuf>,
+        line: usize,
+    },
+    /// A `set` RHS for a bool variable contained a logical operator
+    /// (`and`/`or`/`not`). Logical operators belong in `req`, not in a `set`.
+    LogicalOperatorInSetExpression {
+        file: Option<PathBuf>,
+        line: usize,
+    },
+    /// An `enum` declaration had no `=` sign to introduce the value list.
+    EnumMissingEquals {
+        name: String,
+        file: Option<PathBuf>,
+        line: usize,
+    },
+    /// An `enum` declaration had an empty value list (nothing after `=`).
+    EnumEmptyValueList {
+        name: String,
+        file: Option<PathBuf>,
+        line: usize,
+    },
+    /// An `enum` declaration had an empty value entry (consecutive commas or
+    /// a trailing comma produces an empty string after splitting on `,`).
+    EnumEmptyValue {
+        name: String,
+        file: Option<PathBuf>,
+        line: usize,
+    },
+    /// An enum value was not a valid identifier (e.g. started with a digit).
+    EnumInvalidValue {
+        value: String,
+        file: Option<PathBuf>,
+        line: usize,
+    },
+    /// An enum value matched a reserved keyword (`and`, `or`, `not`).
+    EnumReservedKeywordValue {
+        keyword: String,
+        file: Option<PathBuf>,
+        line: usize,
+    },
+    /// An enum declared the same value name more than once (within one enum).
+    EnumDuplicateValue {
+        value: String,
+        enum_name: String,
+        file: Option<PathBuf>,
+        line: usize,
+    },
 }
 
 /// Render the prefix used in `Display` error lines: the script's file name, or
@@ -1134,6 +1189,95 @@ impl fmt::Display for ParseError {
                 }
                 Ok(())
             }
+            ParseError::BoolSetTypeMismatch {
+                variable,
+                found_token,
+                found,
+                file,
+                line,
+            } => {
+                write!(
+                    f,
+                    "{}:{}: ERROR: Type mismatch: 'set' expression for bool {} must be a bool expression, but {} is {}.",
+                    file_prefix(file),
+                    line,
+                    variable,
+                    found_token,
+                    found.keyword()
+                )
+            }
+            ParseError::LogicalOperatorInSetExpression { file, line } => {
+                write!(
+                    f,
+                    "{}:{}: ERROR: Logical operators (and/or/not) are not allowed in 'set' expressions; use 'req' for boolean expressions.",
+                    file_prefix(file),
+                    line
+                )
+            }
+            ParseError::EnumMissingEquals { name, file, line } => {
+                write!(
+                    f,
+                    "{}:{}: ERROR: Enum '{}' must declare values with '= value1, value2, ...'.",
+                    file_prefix(file),
+                    line,
+                    name
+                )
+            }
+            ParseError::EnumEmptyValueList { name, file, line } => {
+                write!(
+                    f,
+                    "{}:{}: ERROR: Enum '{}' must declare at least one value.",
+                    file_prefix(file),
+                    line,
+                    name
+                )
+            }
+            ParseError::EnumEmptyValue { name, file, line } => {
+                write!(
+                    f,
+                    "{}:{}: ERROR: Empty enum value in enum '{}'.",
+                    file_prefix(file),
+                    line,
+                    name
+                )
+            }
+            ParseError::EnumInvalidValue { value, file, line } => {
+                write!(
+                    f,
+                    "{}:{}: ERROR: Invalid enum value: '{}'. Enum values must start with a letter or underscore.",
+                    file_prefix(file),
+                    line,
+                    value
+                )
+            }
+            ParseError::EnumReservedKeywordValue {
+                keyword,
+                file,
+                line,
+            } => {
+                write!(
+                    f,
+                    "{}:{}: ERROR: Reserved keyword '{}' cannot be used as an enum value.",
+                    file_prefix(file),
+                    line,
+                    keyword
+                )
+            }
+            ParseError::EnumDuplicateValue {
+                value,
+                enum_name,
+                file,
+                line,
+            } => {
+                write!(
+                    f,
+                    "{}:{}: ERROR: Duplicate enum value '{}' in enum '{}'.",
+                    file_prefix(file),
+                    line,
+                    value,
+                    enum_name
+                )
+            }
         }
     }
 }
@@ -1761,6 +1905,23 @@ impl Parser {
                                         file: self.file_path.clone(),
                                         line: context.current_line,
                                     },
+                                    SetParseError::BoolTypeMismatch {
+                                        variable,
+                                        found_token,
+                                        found,
+                                    } => ParseError::BoolSetTypeMismatch {
+                                        variable,
+                                        found_token,
+                                        found,
+                                        file: self.file_path.clone(),
+                                        line: context.current_line,
+                                    },
+                                    SetParseError::LogicalOperatorInSetExpression => {
+                                        ParseError::LogicalOperatorInSetExpression {
+                                            file: self.file_path.clone(),
+                                            line: context.current_line,
+                                        }
+                                    }
                                 };
                                 self.collect_error_and_skip(parse_error, &mut context);
                                 continue;

--- a/parser/src/parsers/set_parser.rs
+++ b/parser/src/parsers/set_parser.rs
@@ -87,12 +87,24 @@ pub enum SetParseError {
     /// `\"`, `\n`, or `\\`. Carries the offending two-character sequence.
     InvalidStringEscape { sequence: String },
     /// A compound assignment (`+=` etc.) targeted a non-numeric variable whose
-    /// kind has a dedicated "not supported" message (currently string). Carries
+    /// kind has a dedicated "not supported" message (string, bool). Carries
     /// the operator and kind so the diagnostic echoes both.
     CompoundAssignmentUnsupported {
         operator: AssignmentOperator,
         kind: ValueKind,
     },
+    /// A `set` on a bool variable had a non-bool RHS. Carries the offending
+    /// sub-expression's source text (`found_token`) and its kind so the
+    /// diagnostic can name it, parallel to the float and string type-mismatch
+    /// variants.
+    BoolTypeMismatch {
+        variable: String,
+        found_token: String,
+        found: ValueKind,
+    },
+    /// A `set` RHS for a bool variable contained a logical operator
+    /// (`and`/`or`/`not`). Logical operators belong in `req`, not `set`.
+    LogicalOperatorInSetExpression,
 }
 
 /// Try to parse `content` as a `set` statement.
@@ -144,6 +156,26 @@ pub(crate) fn parse_set(content: &str, database: &Database) -> Result<ParsedSet,
     }
 
     let lhs_kind = database.variables[variable_id].kind();
+
+    // A bool `set` has its own narrow RHS grammar: `true`, `false`, or a
+    // reference to an earlier bool variable. Logical operators (`and`/`or`/
+    // `not`) and any arithmetic are rejected. Compound assignment makes no
+    // sense for bools. Branch out before the shared arithmetic path so the
+    // bool-specific diagnostics are verbatim.
+    if lhs_kind == ValueKind::Boolean {
+        if operator.is_compound() {
+            return Err(SetParseError::CompoundAssignmentUnsupported {
+                operator,
+                kind: lhs_kind,
+            });
+        }
+        let expression = parse_bool_rhs(rhs, lhs, database)?;
+        return Ok(ParsedSet {
+            variable_id,
+            operator,
+            expression,
+        });
+    }
 
     // A string `set` has its own narrow RHS grammar — a single double-quoted
     // literal or a bare string-variable reference — that the arithmetic body
@@ -270,6 +302,104 @@ fn first_non_float_leaf(
 
 /// Parse the RHS of a `set` whose target is a string variable.
 ///
+/// Parse the RHS of a bool `set` statement.
+///
+/// The grammar is intentionally narrow, mirroring the bool *default* rule:
+/// `true`, `false`, or a bare identifier referencing another bool variable.
+/// Logical operators (`and`/`or`/`not`) are rejected outright because they
+/// belong in `req`. Any non-bool value (int literal, int variable reference)
+/// is a type mismatch that names the offending token.
+fn parse_bool_rhs(rhs: &str, lhs: &str, database: &Database) -> Result<Expression, SetParseError> {
+    // Reject logical operators as whole whitespace-delimited tokens so
+    // identifiers like `or_flag` are unaffected.
+    if rhs
+        .split_whitespace()
+        .any(|token| matches!(token, "and" | "or" | "not"))
+    {
+        return Err(SetParseError::LogicalOperatorInSetExpression);
+    }
+
+    let trimmed = rhs.trim();
+
+    match trimmed {
+        "true" => return Ok(Expression::Literal(Value::Boolean(true))),
+        "false" => return Ok(Expression::Literal(Value::Boolean(false))),
+        _ => {}
+    }
+
+    // A bare identifier: must be a declared bool variable.
+    if is_valid_identifier(trimmed) {
+        return match database.variable_id(trimmed) {
+            None => Err(SetParseError::UndefinedVariable {
+                name: trimmed.to_string(),
+            }),
+            Some(id) => {
+                let kind = database.variables[id].kind();
+                if kind == ValueKind::Boolean {
+                    Ok(Expression::Variable(id))
+                } else {
+                    Err(SetParseError::BoolTypeMismatch {
+                        variable: lhs.to_string(),
+                        found_token: trimmed.to_string(),
+                        found: kind,
+                    })
+                }
+            }
+        };
+    }
+
+    // Not a bool literal and not a bare identifier. Try parsing as an
+    // arithmetic/general expression so we can name the offending non-bool leaf
+    // in the diagnostic. If the expression can't even be parsed, fall back to
+    // a generic type mismatch naming the whole RHS as an int (matching the
+    // default-folder heuristic: unknown shape implies numeric).
+    let resolver = DatabaseResolver { database };
+    match parse_expression(trimmed, &resolver) {
+        Ok(expression) => match first_non_bool_leaf(&expression, database) {
+            Some((found_token, found)) => Err(SetParseError::BoolTypeMismatch {
+                variable: lhs.to_string(),
+                found_token,
+                found,
+            }),
+            None => Err(SetParseError::MalformedExpression {
+                expression: trimmed.to_string(),
+            }),
+        },
+        Err(_) => Err(SetParseError::BoolTypeMismatch {
+            variable: lhs.to_string(),
+            found_token: format!("'{trimmed}'"),
+            found: ValueKind::Integer,
+        }),
+    }
+}
+
+/// Find the first leaf of `expression` whose kind is not `Boolean`, returning
+/// its source-facing text and kind. Parallel to [`first_non_float_leaf`] and
+/// [`first_non_string_leaf`]: a literal leaf is named quoted (`'1'`) and a
+/// variable leaf by its bare identifier (`count`).
+fn first_non_bool_leaf(
+    expression: &Expression,
+    database: &Database,
+) -> Option<(String, ValueKind)> {
+    match expression {
+        Expression::Literal(value) if value.kind() != ValueKind::Boolean => {
+            Some((format!("'{value}'"), value.kind()))
+        }
+        Expression::Literal(_) => None,
+        Expression::Variable(id) => {
+            let variable = &database.variables[*id];
+            if variable.kind() == ValueKind::Boolean {
+                None
+            } else {
+                Some((variable.name.clone(), variable.kind()))
+            }
+        }
+        Expression::Binary { left, right, .. } => {
+            first_non_bool_leaf(left, database).or_else(|| first_non_bool_leaf(right, database))
+        }
+    }
+}
+
 /// The grammar is intentionally narrow, mirroring the string *default* rule:
 /// a single double-quoted literal (with `\"`, `\n`, `\\` escapes) or a bare
 /// identifier referencing another string variable. Anything else is either a

--- a/parser/src/parsers/variables_parser.rs
+++ b/parser/src/parsers/variables_parser.rs
@@ -137,7 +137,12 @@ fn parse_one_declaration(
     let (kind, rest) = match declaration_kind(trimmed) {
         Some((kind, rest)) => (kind, rest),
         None => {
-            if trimmed == "int" || trimmed == "bool" || trimmed == "float" || trimmed == "string" {
+            if trimmed == "int"
+                || trimmed == "bool"
+                || trimmed == "float"
+                || trimmed == "string"
+                || trimmed == "enum"
+            {
                 return Err(ParseError::MissingVariableName {
                     file: file_path.clone(),
                     line: line_number,
@@ -150,6 +155,21 @@ fn parse_one_declaration(
             });
         }
     };
+
+    // Enum declarations have a completely different RHS grammar (a
+    // comma-separated value list, not an arithmetic default). Dispatch before
+    // the shared name/duplicate/default-fold logic so the enum path owns all
+    // of its own diagnostics.
+    if kind == ValueKind::Enum {
+        return parse_enum_declaration(
+            rest,
+            line_number,
+            file_path,
+            declared_lines,
+            declared,
+            database,
+        );
+    }
 
     let (name, default_expr) = if let Some(eq_idx) = rest.find('=') {
         let name = rest[..eq_idx].trim();
@@ -227,6 +247,8 @@ fn parse_one_declaration(
             file_path,
             line_number,
         )?,
+        // Enum is handled above via the early-return path.
+        ValueKind::Enum => unreachable!("enum handled before this match"),
     };
 
     declared_lines.insert(name.to_string(), line_number);
@@ -235,10 +257,145 @@ fn parse_one_declaration(
     Ok(())
 }
 
+/// Parse an `enum <name> = <value1>, <value2>, ...` declaration (the `rest`
+/// argument is everything after the `enum ` keyword, e.g. `mood = happy, sad`).
+///
+/// Validates the name (identifier, non-reserved, non-duplicate), then parses
+/// and validates the comma-separated value list, and finally registers the
+/// variable in the database with an `EnumUnset` initial value.
+fn parse_enum_declaration(
+    rest: &str,
+    line_number: usize,
+    file_path: &Option<PathBuf>,
+    declared_lines: &mut HashMap<String, usize>,
+    declared: &mut HashMap<String, Value>,
+    database: &mut Database,
+) -> Result<(), ParseError> {
+    // Split on the first `=` to separate name from value list.
+    let (name_raw, value_list_raw) = match rest.find('=') {
+        Some(eq_idx) => (rest[..eq_idx].trim(), Some(rest[eq_idx + 1..].trim())),
+        None => (rest.trim(), None),
+    };
+
+    let name = name_raw;
+
+    if name.is_empty() {
+        return Err(ParseError::MissingVariableName {
+            file: file_path.clone(),
+            line: line_number,
+        });
+    }
+
+    // Validate name: for `enum mood happy, sad` (no `=`) the "name" would be
+    // `mood happy, sad` — not a valid identifier, but the missing-equals error
+    // is more informative. We detect the missing `=` and report it specifically.
+    if value_list_raw.is_none() {
+        // There was no `=`. The first word is the name; whatever follows is noise.
+        let name_word = name.split_whitespace().next().unwrap_or(name);
+        return Err(ParseError::EnumMissingEquals {
+            name: name_word.to_string(),
+            file: file_path.clone(),
+            line: line_number,
+        });
+    }
+
+    // The name itself should be a valid identifier at this point.
+    if !is_valid_identifier(name) {
+        return Err(ParseError::InvalidVariableName {
+            name: name.to_string(),
+            file: file_path.clone(),
+            line: line_number,
+        });
+    }
+
+    if is_reserved_keyword(name) {
+        return Err(ParseError::ReservedKeyword {
+            name: name.to_string(),
+            file: file_path.clone(),
+            line: line_number,
+        });
+    }
+
+    if let Some(&previous_line) = declared_lines.get(name) {
+        return Err(ParseError::DuplicateVariable {
+            name: name.to_string(),
+            previous_line,
+            file: file_path.clone(),
+            line: line_number,
+        });
+    }
+
+    let raw_list = value_list_raw.unwrap();
+
+    // An empty value list is an error.
+    if raw_list.is_empty() {
+        return Err(ParseError::EnumEmptyValueList {
+            name: name.to_string(),
+            file: file_path.clone(),
+            line: line_number,
+        });
+    }
+
+    // Parse the comma-separated value list. Each entry must be a non-empty,
+    // valid identifier that is not a reserved keyword. Duplicates within this
+    // enum are also rejected (but two different enums sharing a value name is
+    // fine — the duplicate check is per-enum, not global).
+    let mut variants: Vec<String> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+
+    for raw_value in raw_list.split(',') {
+        let value = raw_value.trim();
+        if value.is_empty() {
+            return Err(ParseError::EnumEmptyValue {
+                name: name.to_string(),
+                file: file_path.clone(),
+                line: line_number,
+            });
+        }
+        if !is_valid_identifier(value) {
+            return Err(ParseError::EnumInvalidValue {
+                value: value.to_string(),
+                file: file_path.clone(),
+                line: line_number,
+            });
+        }
+        if is_reserved_keyword(value) {
+            return Err(ParseError::EnumReservedKeywordValue {
+                keyword: value.to_string(),
+                file: file_path.clone(),
+                line: line_number,
+            });
+        }
+        if !seen.insert(value.to_string()) {
+            return Err(ParseError::EnumDuplicateValue {
+                value: value.to_string(),
+                enum_name: name.to_string(),
+                file: file_path.clone(),
+                line: line_number,
+            });
+        }
+        variants.push(value.to_string());
+    }
+
+    let initial_value = Value::EnumUnset {
+        variants: variants.clone(),
+    };
+
+    declared_lines.insert(name.to_string(), line_number);
+    // Store a sentinel in `declared` so later declarations can see this name.
+    // We use the `EnumUnset` value directly; the type checks for other kinds
+    // (integer, bool, float, string) already reject cross-kind references, so
+    // storing `EnumUnset` here means any attempt to use an enum name in another
+    // variable's default will hit the type-mismatch path naturally.
+    declared.insert(name.to_string(), initial_value.clone());
+    database.add_variable(Variable::new(name, initial_value));
+    Ok(())
+}
+
 /// Recognize a declaration's leading type keyword. Returns the declared
 /// [`ValueKind`] and the remainder of the line (the name and optional
-/// default), with leading whitespace after the keyword stripped. `None`
-/// means the line is not a recognized `<keyword> ...` declaration.
+/// default / value-list), with leading whitespace after the keyword stripped.
+/// `None` means the line is not a recognized `<keyword> ...` declaration.
 fn declaration_kind(trimmed: &str) -> Option<(ValueKind, &str)> {
     if let Some(rest) = trimmed.strip_prefix("int ") {
         Some((ValueKind::Integer, rest.trim_start()))
@@ -248,6 +405,8 @@ fn declaration_kind(trimmed: &str) -> Option<(ValueKind, &str)> {
         Some((ValueKind::Float, rest.trim_start()))
     } else if let Some(rest) = trimmed.strip_prefix("string ") {
         Some((ValueKind::String, rest.trim_start()))
+    } else if let Some(rest) = trimmed.strip_prefix("enum ") {
+        Some((ValueKind::Enum, rest.trim_start()))
     } else {
         None
     }
@@ -1025,9 +1184,9 @@ fn parse_string_literal(input: &str) -> Result<String, StringDefaultError> {
 }
 
 /// Scan lines `[start, end)` (exclusive end) for identifiers that follow a
-/// type keyword (`int `/`bool `/`float `/`string `), collecting them into a set
-/// regardless of declared type. Duplicate identifiers are merged silently
-/// here; duplicate-declaration detection lives in the main pass.
+/// type keyword (`int `/`bool `/`float `/`string `/`enum `), collecting them
+/// into a set regardless of declared type. Duplicate identifiers are merged
+/// silently here; duplicate-declaration detection lives in the main pass.
 fn collect_future_names(lines: &[&str], start: usize, end: usize) -> HashSet<String> {
     let mut names = HashSet::new();
     for line in &lines[start..end] {
@@ -1036,6 +1195,9 @@ fn collect_future_names(lines: &[&str], start: usize, end: usize) -> HashSet<Str
             Some((_, rest)) => rest,
             None => continue,
         };
+        // For all types, the variable name is before any `=`. For `enum` this
+        // is correct too: `enum mood = happy, sad` → rest = `mood = happy, sad`
+        // → name = `mood`.
         let name = if let Some(eq_idx) = rest.find('=') {
             rest[..eq_idx].trim()
         } else {
@@ -1158,12 +1320,15 @@ pub fn evaluate_expression(
             Value::Integer(n) => Ok(n),
             // The resolver only exposes integer-typed variables and the shared
             // parser only produces integer arithmetic, so the fold never
-            // yields a boolean or float. (Boolean and float defaults bypass
-            // this folder entirely — see `evaluate_bool_default` /
-            // `evaluate_float_default`.)
+            // yields a boolean, float, string, or enum. (Boolean and float
+            // defaults bypass this folder entirely — see `evaluate_bool_default`
+            // / `evaluate_float_default`.)
             Value::Boolean(_) => unreachable!("integer-default fold never yields a boolean"),
             Value::Float(_) => unreachable!("integer-default fold never yields a float"),
             Value::String(_) => unreachable!("integer-default fold never yields a string"),
+            Value::EnumUnset { .. } => {
+                unreachable!("integer-default fold never yields an enum")
+            }
         },
         Err(EvaluationError::DivisionByZero) => Err(EvalError::DivisionByZero),
         Err(EvaluationError::Overflow) => Err(EvalError::Overflow),


### PR DESCRIPTION
## Summary

- Adds `enum <name> = v1, v2, ...` declarations to the `--- variables` block
- Adds `Value::EnumUnset { variants }` and `ValueKind::Enum` to `cuentitos-common`
- Parser validates: missing `=`, empty value list, empty values, invalid identifiers, reserved keywords, duplicate values (per-enum scope)
- `?` debug inspector renders unset enums as `<unset>`
- Fixes bool `set` error messages: compound assignment uses `CompoundAssignmentUnsupported`, type mismatches use named-token format matching float/string, logical operators get a dedicated diagnostic
- All 479 compatibility tests pass; fmt/clippy clean

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` — 418 unit tests pass
- [x] `./bin/run-compat` — 479/479 pass (0 failures)